### PR TITLE
fix fields with format attr1=attr2 not recognized

### DIFF
--- a/rvdecoderdb/src/parser/SameValue.scala
+++ b/rvdecoderdb/src/parser/SameValue.scala
@@ -1,0 +1,13 @@
+package org.chipsalliance.rvdecoderdb.parser
+import org.chipsalliance.rvdecoderdb.parser.ArgLUT
+
+object SameValue {
+  def unapply(str: String): Option[ArgLUT] = str match {
+    case s"${attr1}=${attr2}" => ArgLUT.all.get(attr1)
+    case _                    => None
+  }
+}
+
+class SameValue(val attr1: String, val attr2: String) extends Token {
+  override def toString: String = s"$attr1=$attr2"
+}

--- a/rvdecoderdb/src/parser/parse.scala
+++ b/rvdecoderdb/src/parser/parse.scala
@@ -18,6 +18,7 @@ object parse {
           custom,
           content
             .split("\n")
+            .map(_.trim)
             .filter(!_.startsWith("#"))
             .filter(_.nonEmpty)
             .map(
@@ -27,6 +28,7 @@ object parse {
                   case "$import"          => Import
                   case "$pseudo_op"       => PseudoOp
                   case RefInst(i)         => i
+                  case SameValue(s)       => s
                   case FixedRangeValue(f) => f
                   case BitValue(b)        => b
                   case ArgLUT(a)          => a


### PR DESCRIPTION
rvdecoderdb could not recognize fields like "attr1=attr2", so I added a new Token, `SameValue`, for pattern matching. Additionally, I noticed that without using the `trim` method in parse.scala, blank lines would still appear, so I added that as well.