### PR TITLE
Fix build

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -8,7 +8,7 @@ import mill.scalalib.scalafmt._
 
 object v {
   val scala = "2.13.16"
-  val scalajs = "1.14.0"
+  val scalajs = "1.18.2"
   object jvm {
     val oslib = ivy"com.lihaoyi::os-lib:0.9.1"
     val upickle = ivy"com.lihaoyi::upickle:3.3.1"

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
           commonDeps = with pkgs; [
             mill
             espresso
+            pkgs.mill-ivy-fetcher
           ];
 
         in

--- a/nix/rvdecoderdb-jvm-mill-lock.nix
+++ b/nix/rvdecoderdb-jvm-mill-lock.nix
@@ -934,14 +934,14 @@
       mkdir -p "$out"
       cp -v "$downloadedFile" "$out/compiler-bridge_2.13-1.10.7.pom"
             
-      downloadedFile=$TMPDIR/compiler-bridge_2.13-1.10.7-sources.jar
-      tryDownload "https://repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.13/1.10.7/compiler-bridge_2.13-1.10.7-sources.jar"
-      cp -v "$TMPDIR/compiler-bridge_2.13-1.10.7-sources.jar" "$out/"
-
-      
       downloadedFile=$TMPDIR/compiler-bridge_2.13-1.10.7.jar
       tryDownload "https://repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.13/1.10.7/compiler-bridge_2.13-1.10.7.jar"
       cp -v "$TMPDIR/compiler-bridge_2.13-1.10.7.jar" "$out/"
+
+      
+      downloadedFile=$TMPDIR/compiler-bridge_2.13-1.10.7-sources.jar
+      tryDownload "https://repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.13/1.10.7/compiler-bridge_2.13-1.10.7-sources.jar"
+      cp -v "$TMPDIR/compiler-bridge_2.13-1.10.7-sources.jar" "$out/"
 
     '';
     passthru.installPath = "https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.13/1.10.7";
@@ -975,14 +975,14 @@
       mkdir -p "$out"
       cp -v "$downloadedFile" "$out/compiler-interface-1.10.7.pom"
             
-      downloadedFile=$TMPDIR/compiler-interface-1.10.7-sources.jar
-      tryDownload "https://repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.10.7/compiler-interface-1.10.7-sources.jar"
-      cp -v "$TMPDIR/compiler-interface-1.10.7-sources.jar" "$out/"
-
-      
       downloadedFile=$TMPDIR/compiler-interface-1.10.7.jar
       tryDownload "https://repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.10.7/compiler-interface-1.10.7.jar"
       cp -v "$TMPDIR/compiler-interface-1.10.7.jar" "$out/"
+
+      
+      downloadedFile=$TMPDIR/compiler-interface-1.10.7-sources.jar
+      tryDownload "https://repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.10.7/compiler-interface-1.10.7-sources.jar"
+      cp -v "$TMPDIR/compiler-interface-1.10.7-sources.jar" "$out/"
 
     '';
     passthru.installPath = "https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.10.7";
@@ -1124,14 +1124,14 @@
       mkdir -p "$out"
       cp -v "$downloadedFile" "$out/util-interface-1.10.7.pom"
             
-      downloadedFile=$TMPDIR/util-interface-1.10.7-sources.jar
-      tryDownload "https://repo1.maven.org/maven2/org/scala-sbt/util-interface/1.10.7/util-interface-1.10.7-sources.jar"
-      cp -v "$TMPDIR/util-interface-1.10.7-sources.jar" "$out/"
-
-      
       downloadedFile=$TMPDIR/util-interface-1.10.7.jar
       tryDownload "https://repo1.maven.org/maven2/org/scala-sbt/util-interface/1.10.7/util-interface-1.10.7.jar"
       cp -v "$TMPDIR/util-interface-1.10.7.jar" "$out/"
+
+      
+      downloadedFile=$TMPDIR/util-interface-1.10.7-sources.jar
+      tryDownload "https://repo1.maven.org/maven2/org/scala-sbt/util-interface/1.10.7/util-interface-1.10.7-sources.jar"
+      cp -v "$TMPDIR/util-interface-1.10.7-sources.jar" "$out/"
 
     '';
     passthru.installPath = "https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.10.7";
@@ -1674,4 +1674,4 @@
   };
 
 }
-# Project Source Hash:sha256-ue2hGEVND34dC9meO3E0Tr520oDiCo3gJFlyOv3DOMo=
+# Project Source Hash:sha256-aEMIACRiFzz1CHs7CtwdUVNCBhaw+DmfkgaDIv/y8oM=

--- a/nix/rvdecoderdb-jvm.nix
+++ b/nix/rvdecoderdb-jvm.nix
@@ -36,7 +36,7 @@ publishMillJar rec {
       mif run \
         --targets rvdecoderdb.jvm \
         -p "$sourceDir"/rvdecoderdb \
-        -o ./nix/rvdecoderdb-mill-lock.nix
+        -o ./nix/rvdecoderdb-jvm-mill-lock.nix
     '';
   };
 }


### PR DESCRIPTION
`org.scala-js:scalajs-compiler_2.13.16:1.14.0` does not exist
