### PR TITLE
[package] change the search directory of extensions

### DIFF
--- a/rvdecoderdb/jvm/src/package.scala
+++ b/rvdecoderdb/jvm/src/package.scala
@@ -19,7 +19,7 @@ package object rvdecoderdb {
     }
 
     val official = os
-      .walk(riscvOpcodes)
+      .walk(riscvOpcodes / "extensions")
       .filter(isInstructionSetFile)
       .map(f => (f.baseName, os.read(f), !f.segments.contains("unratified"), false))
 


### PR DESCRIPTION
Change the search directory of extension to `riscvOpcodes/extensions`.